### PR TITLE
ALF-21953: updated pom to use super-pom v9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-super-pom</artifactId>
-        <version>8</version>
+        <version>9</version>
     </parent>
 
     <modules>


### PR DESCRIPTION
Updated the pom to use the newly released alfresco-super-pom v9. The new super pom includes the snippet:

```
  <pluginRepositories>
    <pluginRepository>
      <id>alfresco-public</id>
      <url>https://artifacts.alfresco.com/nexus/content/groups/public</url>
      <snapshots>
        <enabled>false</enabled>
      </snapshots>
    </pluginRepository>
  </pluginRepositories>
```

So that the alfresco-license-header (plugin or example?) can be retrieved and checked during packaging. Without this the acs-community-packaging project fails.

