### PR TITLE
REPO-3120 Remove commons-modeler as unused

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -187,6 +187,7 @@
                 <artifactId>commons-collections</artifactId>
                 <version>3.2.2</version>
             </dependency>
+            <!-- Use 2.1 version as a newer dependency for commons-validator -->
             <dependency>
                 <groupId>commons-digester</groupId>
                 <artifactId>commons-digester</artifactId>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -44,17 +44,6 @@
             <version>1.3</version>
         </dependency>
         <dependency>
-            <groupId>commons-modeler</groupId>
-            <artifactId>commons-modeler</artifactId>
-            <version>2.0.1</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>commons-logging</groupId>
-                    <artifactId>commons-logging-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
             <version>1.2</version>

--- a/zip/src/main/resources/licenses/notice.txt
+++ b/zip/src/main/resources/licenses/notice.txt
@@ -40,8 +40,7 @@ commons-jxpath  http://jakarta.apache.org/commons/
 commons-lang    http://jakarta.apache.org/commons/ 
 commons-lang3   http://jakarta.apache.org/commons/ 
 commons-logging http://jakarta.apache.org/commons/ 
-commons-modeler http://jakarta.apache.org/commons/ 
-commons-net http://jakarta.apache.org/commons/ 
+commons-net http://jakarta.apache.org/commons/
 commons-pool    http://jakarta.apache.org/commons/ 
 commons-validator   http://jakarta.apache.org/commons/ 
 ConcurrentLinkedHashMap     http://code.google.com/p/concurrentlinkedhashmap/


### PR DESCRIPTION
The commons-modeler has commons-digester as a dependency. It appeared
that the modeler is not used, so was removed. Commons-digester is still a
dependency for commons-validator and newer version of commons-digester
needs to be enforced.