### PR TITLE
REPO-3256: EOL:Disable CIFS and FTP by default

### DIFF
--- a/docker-alfresco/test/docker-compose.yml
+++ b/docker-alfresco/test/docker-compose.yml
@@ -19,6 +19,7 @@ services:
                 -Dftp.enabled=true
                 -Dftp.dataPortFrom=30000
                 -Dftp.dataPortTo=30099
+                -Dcifs.enable=true
                 "
         ports:
             - 8080:8080

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 
         <dependency.alfresco-core.version>7.0</dependency.alfresco-core.version>
         <dependency.alfresco-data-model.version>8.0</dependency.alfresco-data-model.version>
-        <dependency.alfresco-repository.version>6.33</dependency.alfresco-repository.version>
+        <dependency.alfresco-repository.version>6.34</dependency.alfresco-repository.version>
         <dependency.alfresco-remote-api.version>6.20</dependency.alfresco-remote-api.version>
 
         <dependency.alfresco-mmt.version>6.0</dependency.alfresco-mmt.version>


### PR DESCRIPTION
 -  Adding parameter Dcifs.enabled=true on test/docker compose
 -  Upgrade alfresco-repository version to 6.34