### PR TITLE
REPO-3447 Remove c3p0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,19 @@
                 <version>1.2.5</version>
             </dependency>
             <dependency>
+                <groupId>org.quartz-scheduler</groupId>
+                <artifactId>quartz</artifactId>
+                <version>2.3.0</version>
+                <!-- exclude c3p0 -->
+                <!-- see https://issues.alfresco.com/jira/browse/REPO-3447 -->
+                <exclusions>
+                    <exclusion>
+                        <groupId>com.mchange</groupId>
+                        <artifactId>*</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpcore</artifactId>
                 <version>4.4.5</version>


### PR DESCRIPTION
Quartz uses c3p0 jdbc pool for it's distributed job storage since version 2.x
This commit will exclude c3p0 lib as distributed job storage is not used.