### PR TITLE
GOOGLEDOCS-429 : Generate RC2 for GoogleDocs 3.1.0 compatible with ACS Ent 6.0

### DIFF
--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -59,9 +59,8 @@
         </dependency>
         <dependency>
             <groupId>org.alfresco.integrations</groupId>
-            <artifactId>alfresco-googledocs-repo</artifactId>
+            <artifactId>alfresco-googledocs-repo-community</artifactId>
             <version>${alfresco.googledocs.version}</version>
-            <classifier>community</classifier>
             <type>amp</type>
         </dependency>
     </dependencies>
@@ -156,12 +155,19 @@
                                 </artifactItem>
                                 <artifactItem>
                                     <groupId>org.alfresco.integrations</groupId>
-                                    <artifactId>alfresco-googledocs-repo</artifactId>
+                                    <artifactId>alfresco-googledocs-repo-community</artifactId>
                                     <version>${alfresco.googledocs.version}</version>
-                                    <classifier>community</classifier>
                                     <type>amp</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.alfresco.integrations</groupId>
+                                    <artifactId>alfresco-googledocs-share-community</artifactId>
+                                    <version>${alfresco.googledocs.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -161,14 +161,6 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
-                                <artifactItem>
-                                    <groupId>org.alfresco.integrations</groupId>
-                                    <artifactId>alfresco-googledocs-share-community</artifactId>
-                                    <version>${alfresco.googledocs.version}</version>
-                                    <type>amp</type>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}/amps_share</outputDirectory>
-                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <alfresco.alfresco-share-services.version>6.0.a</alfresco.alfresco-share-services.version>
 
         <!-- Alfresco GoogleDocs integration version -->
-        <alfresco.googledocs.version>3.1.0-RC1</alfresco.googledocs.version>
+        <alfresco.googledocs.version>3.1.0-RC2</alfresco.googledocs.version>
 
         <!-- Alfresco Office Services Module -->
         <alfresco.aos-module.version>1.2.0-RC2</alfresco.aos-module.version>
@@ -451,16 +451,14 @@
             </dependency>
             <dependency>
                 <groupId>org.alfresco.integrations</groupId>
-                <artifactId>alfresco-googledocs-repo</artifactId>
+                <artifactId>alfresco-googledocs-repo-community</artifactId>
                 <version>${alfresco.googledocs.version}</version>
-                <classifier>community</classifier>
                 <type>amp</type>
             </dependency>
             <dependency>
                 <groupId>org.alfresco.integrations</groupId>
-                <artifactId>alfresco-googledocs-share</artifactId>
+                <artifactId>alfresco-googledocs-share-community</artifactId>
                 <version>${alfresco.googledocs.version}</version>
-                <classifier>community</classifier>
                 <type>amp</type>
             </dependency>
 


### PR DESCRIPTION
   - updated googledocs dependencies