### PR TITLE
Removed alfresco-events dependency as it's been added to alfresco-rep…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,8 +64,8 @@
 
         <dependency.alfresco-core.version>7.3</dependency.alfresco-core.version>
         <dependency.alfresco-data-model.version>8.8</dependency.alfresco-data-model.version>
-        <dependency.alfresco-repository.version>7.3</dependency.alfresco-repository.version>
-        <dependency.alfresco-remote-api.version>6.38</dependency.alfresco-remote-api.version>
+        <dependency.alfresco-repository.version>7.4</dependency.alfresco-repository.version>
+        <dependency.alfresco-remote-api.version>7.0</dependency.alfresco-remote-api.version>
         <dependency.alfresco-hb-data-sender.version>1.0.9</dependency.alfresco-hb-data-sender.version>
         <dependency.alfresco-spring-webscripts.version>6.19</dependency.alfresco-spring-webscripts.version>
         <dependency.alfresco-mmt.version>6.0</dependency.alfresco-mmt.version>

--- a/pom.xml
+++ b/pom.xml
@@ -193,11 +193,6 @@
                 <type>war</type>
             </dependency>
             <dependency>
-                <groupId>org.alfresco.services</groupId>
-                <artifactId>alfresco-events</artifactId>
-                <version>1.2.12</version>
-            </dependency>
-            <dependency>
                 <groupId>org.alfresco.surf</groupId>
                 <artifactId>spring-surf-core-configservice</artifactId>
                 <version>${dependency.alfresco-spring-webscripts.version}</version>


### PR DESCRIPTION
EGATE-35/EGATE-58: Removed 'alfresco-events' dependency as it's been added to alfresco-repository project. The name has been changed to alfresco-repository-events