### PR TITLE
REPO-3539 : Integrate Api-Explorer

### DIFF
--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -25,6 +25,12 @@
         </dependency>
         <dependency>
             <groupId>org.alfresco</groupId>
+            <artifactId>api-explorer</artifactId>
+            <version>${dependency.alfresco-api-explorer.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>org.alfresco</groupId>
             <artifactId>alfresco-server-root</artifactId>
             <version>${dependency.alfresco-server-root.version}</version>
             <type>war</type>
@@ -88,6 +94,14 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/war/alfresco</outputDirectory>
                                     <destFileName>alfresco.war</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>api-explorer</artifactId>
+                                    <version>${dependency.alfresco-api-explorer.version}</version>
+                                    <type>war</type>
+                                    <outputDirectory>${project.build.directory}/war/api-explorer</outputDirectory>
+                                    <destFileName>api-explorer.war</destFileName>
                                 </artifactItem>
                             </artifactItems>
                         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
         <dependency.alfresco-jlan.version>7.1</dependency.alfresco-jlan.version>
         <dependency.alfresco-server-root.version>6.0</dependency.alfresco-server-root.version>
         <dependency.alfresco-messaging-repo.version>1.2.9</dependency.alfresco-messaging-repo.version>
+        <dependency.alfresco-api-explorer.version>6.0.7-ga</dependency.alfresco-api-explorer.version>
 
         <dependency.spring.version>5.0.4.RELEASE</dependency.spring.version>
         <dependency.fabric8.version>3.5.37</dependency.fabric8.version>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 
         <dependency.alfresco-core.version>7.3</dependency.alfresco-core.version>
         <dependency.alfresco-data-model.version>8.8</dependency.alfresco-data-model.version>
-        <dependency.alfresco-repository.version>6.55</dependency.alfresco-repository.version>
+        <dependency.alfresco-repository.version>7.3</dependency.alfresco-repository.version>
         <dependency.alfresco-remote-api.version>6.38</dependency.alfresco-remote-api.version>
         <dependency.alfresco-hb-data-sender.version>1.0.9</dependency.alfresco-hb-data-sender.version>
         <dependency.alfresco-spring-webscripts.version>6.19</dependency.alfresco-spring-webscripts.version>

--- a/war/src/main/webapp/index.jsp
+++ b/war/src/main/webapp/index.jsp
@@ -88,7 +88,7 @@ ModuleDetails shareServicesModule = moduleService.getModule("alfresco-share-serv
             <p></p>
             <p><a href="./s/index">Alfresco WebScripts Home</a> (admin only - INTERNAL)</p>
             <p></p>
-            <p><a href="<%=request.getRequestURL().toString().replace(request.getRequestURI(),"/api-explorer")%>">Alfresco API Explorer</a></p>
+            <p><a href="<%=UrlUtil.getApiExplorerUrl(sysAdminParams, request.getRequestURL().toString(), request.getRequestURI())%>">Alfresco API Explorer</a></p>
 <%
    if (descriptorService.getLicenseDescriptor() == null && transactionService.isReadOnly())
    {

--- a/war/src/main/webapp/index.jsp
+++ b/war/src/main/webapp/index.jsp
@@ -86,7 +86,9 @@ ModuleDetails shareServicesModule = moduleService.getModule("alfresco-share-serv
              %>
             <p><a href="./webdav">Alfresco WebDav</a></p>
             <p></p>
-            <p><a href="./s/index">Alfresco WebScripts Home</a> (admin only)</p>
+            <p><a href="./s/index">Alfresco WebScripts Home</a> (admin only - INTERNAL)</p>
+            <p></p>
+            <p><a href="<%=request.getRequestURL().toString().replace(request.getRequestURI(),"/api-explorer")%>">Alfresco API Explorer</a></p>
 <%
    if (descriptorService.getLicenseDescriptor() == null && transactionService.isReadOnly())
    {


### PR DESCRIPTION
   Add alfresco-api-explorer version property to pom.xml
   Add alfresco-api-explorer dependency to docker-alfresco/pom.xml and unpack it using maven-dependency-plugin
   Marked "Alfresco WebScripts - Home" as internal
   Add url api-explorer to index.jsp