### PR TITLE
REPO-4172: Add Licenses directory to the root of docker image

### DIFF
--- a/docker-alfresco/Dockerfile
+++ b/docker-alfresco/Dockerfile
@@ -61,7 +61,7 @@ COPY target/alfresco-mmt/* /usr/local/tomcat/alfresco-mmt/
 
 # Copy Licenses to the root of the Docker image
 RUN mkdir /licenses
-COPY ${resource_path}/licenses/ /licenses/
+COPY target/licenses/ /licenses/
 
 # Change the value of the shared.loader= property to the following:
 # shared.loader=${catalina.base}/shared/classes

--- a/docker-alfresco/Dockerfile
+++ b/docker-alfresco/Dockerfile
@@ -59,6 +59,10 @@ COPY target/war /usr/local/tomcat/webapps
 COPY target/connector/* /usr/local/tomcat/lib/
 COPY target/alfresco-mmt/* /usr/local/tomcat/alfresco-mmt/
 
+# Copy Licenses to the root of the Docker image
+RUN mkdir /licenses
+COPY ${resource_path}/dependency/licenses/ /licenses/
+
 # Change the value of the shared.loader= property to the following:
 # shared.loader=${catalina.base}/shared/classes
 RUN sed -i "s/shared.loader=/shared.loader=\${catalina.base}\/shared\/classes/" /usr/local/tomcat/conf/catalina.properties

--- a/docker-alfresco/Dockerfile
+++ b/docker-alfresco/Dockerfile
@@ -61,7 +61,7 @@ COPY target/alfresco-mmt/* /usr/local/tomcat/alfresco-mmt/
 
 # Copy Licenses to the root of the Docker image
 RUN mkdir /licenses
-COPY ${resource_path}/dependency/licenses/ /licenses/
+COPY ${resource_path}/licenses/ /licenses/
 
 # Change the value of the shared.loader= property to the following:
 # shared.loader=${catalina.base}/shared/classes

--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -19,11 +19,6 @@
     <dependencies>
         <dependency>
             <groupId>org.alfresco</groupId>
-            <artifactId>alfresco-content-services-community-distribution</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.alfresco</groupId>
             <artifactId>content-services-community</artifactId>
             <version>${project.version}</version>
             <type>war</type>
@@ -80,26 +75,33 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                   <execution>
+                      <id>copy-licenses</id>
+                      <phase>process-resources</phase>
+                      <goals>
+                          <goal>copy-resources</goal>
+                      </goals>
+                      <configuration>
+                          <resources>
+                              <resource>
+                                  <!-- Extract licenses directory -->
+                                  <directory>../distribution/src/main/resources/licenses</directory>
+                                  <filtering>false</filtering>
+                              </resource>
+                          </resources>
+                          <outputDirectory>${project.build.directory}/licenses</outputDirectory>
+                      </configuration>
+                   </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.0.2</version>
                 <executions>
-                    <execution>
-                        <id>extract-licenses</id>
-                        <phase>generate-resources</phase>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <configuration>
-                            <artifactItems>
-                                <!-- Extract licenses directory from distribution jar -->
-                                <artifactItem>
-                                    <groupId>org.alfresco</groupId>
-                                    <artifactId>alfresco-content-services-community-distribution</artifactId>
-                                    <includes>licenses/**</includes>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
                     <execution>
                         <id>unpack-war-files</id>
                         <phase>process-resources</phase>

--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -19,6 +19,11 @@
     <dependencies>
         <dependency>
             <groupId>org.alfresco</groupId>
+            <artifactId>alfresco-content-services-distribution</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.alfresco</groupId>
             <artifactId>content-services-community</artifactId>
             <version>${project.version}</version>
             <type>war</type>
@@ -78,6 +83,23 @@
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.0.2</version>
                 <executions>
+                    <execution>
+                        <id>extract-licenses</id>
+                        <phase>generate-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <!-- Extract licenses directory from distribution jar -->
+                                <artifactItem>
+                                    <groupId>org.alfresco</groupId>
+                                    <artifactId>alfresco-content-services-distribution</artifactId>
+                                    <includes>licenses/**</includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>unpack-war-files</id>
                         <phase>process-resources</phase>

--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -19,7 +19,7 @@
     <dependencies>
         <dependency>
             <groupId>org.alfresco</groupId>
-            <artifactId>alfresco-content-services-distribution</artifactId>
+            <artifactId>alfresco-content-services-community-distribution</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
@@ -94,7 +94,7 @@
                                 <!-- Extract licenses directory from distribution jar -->
                                 <artifactItem>
                                     <groupId>org.alfresco</groupId>
-                                    <artifactId>alfresco-content-services-distribution</artifactId>
+                                    <artifactId>alfresco-content-services-community-distribution</artifactId>
                                     <includes>licenses/**</includes>
                                 </artifactItem>
                             </artifactItems>


### PR DESCRIPTION
- All licenses (including 3rd party) should be under /licenses directory of the docker image.