### PR TITLE
Support fine-grained config (global properties / Log4J)

### DIFF
--- a/docker-alfresco/Dockerfile
+++ b/docker-alfresco/Dockerfile
@@ -29,6 +29,17 @@ RUN chgrp -R ${GROUPNAME} ${TOMCAT_DIR}/webapps ${TOMCAT_DIR}/amps ${TOMCAT_DIR}
     find ${TOMCAT_DIR}/webapps -type d -exec chmod 0750 {} \; && \
     find ${TOMCAT_DIR}/webapps -type f -exec chmod 0640 {} \; && \
     chmod -R g+r ${TOMCAT_DIR}/webapps && \
-    chmod 664 ${TOMCAT_DIR}/amps/*
+    chmod 664 ${TOMCAT_DIR}/amps/* && \
+    mkdir -p ${TOMCAT_DIR}/shared/classes/alfresco && \
+    chown -R ${IMAGEUSERNAME}:${GROUPNAME} ${TOMCAT_DIR}/shared/classes && \
+    find ${TOMCAT_DIR}/shared/ -type d -exec chmod 0750 {} \; && \
+    sed -i -e "s_log4j.appender.File.File\=alfresco.log_log4j.appender.File.File\=${TOMCAT_DIR}/logs\/alfresco.log_" \ 
+        ${TOMCAT_DIR}/webapps/alfresco/WEB-INF/classes/log4j.properties
+
+COPY entrypoint.sh ${TOMCAT_DIR}/shared/classes/alfresco
+RUN chown ${IMAGEUSERNAME}:${GROUPNAME} ${TOMCAT_DIR}/shared/classes/alfresco/entrypoint.sh && \
+    chmod 0750 ${TOMCAT_DIR}/shared/classes/alfresco/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/tomcat/shared/classes/alfresco/entrypoint.sh", "catalina.sh run"]
 
 USER ${IMAGEUSERNAME}

--- a/docker-alfresco/entrypoint.sh
+++ b/docker-alfresco/entrypoint.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+
+set -e
+
+setInPropertiesFile() {
+   local fileName="$1"
+   local key="$2"
+   local value="${3:-''}"
+
+   # escape typical special characters in key / value (. and / for dot-separated keys or path values)
+   regexSafeKey=`echo "$key" | sed -r 's/\\//\\\\\//g' | sed -r 's/\\./\\\\\./g'`
+   replacementSafeKey=`echo "$key" | sed -r 's/\\//\\\\\//g' | sed -r 's/&/\\\\&/g'`
+   replacementSafeValue=`echo "$value" | sed -r 's/\\//\\\\\//g' | sed -r 's/&/\\\\&/g'`
+
+   if grep --quiet -E "^#?${regexSafeKey}=" ${fileName}; then
+      sed -i -r "s/^#?${regexSafeKey}=.*/${replacementSafeKey}=${replacementSafeValue}/" ${fileName}
+   else
+      echo "${key}=${value}" >> ${fileName}
+   fi
+}
+
+TOMCAT_DIR=/usr/local/tomcat
+
+# ensure alfresco-global.properties / custom-log4j.properties exist and end with proper line ending
+echo "" >> ${TOMCAT_DIR}/shared/classes/alfresco-global.properties
+echo "" >> ${TOMCAT_DIR}/shared/classes/alfresco/extension/custom-log4j.properties
+
+# otherwise for will also cut on whitespace
+IFS=$'\n'
+for i in `env`
+do
+   key=`echo "$i" | cut -d '=' -f 1 | cut -d '_' -f 2-`
+   value=`echo "$i" | cut -d '=' -f 2-`
+      
+   if [[ $i == GLOBAL_* ]]
+   then
+      echo "Processing ENV global properties key ${key} with value ${value}"
+
+      # support secrets mounted via files
+      if [[ $key == *_FILE ]]
+      then
+         value="$(< "${value}")"
+         key=`echo "$key" | sed -r 's/_FILE$//'`
+      fi
+      
+      setInPropertiesFile ${TOMCAT_DIR}/shared/classes/alfresco-global.properties ${key} ${value}
+
+   elif [[ $i == LOG4J-LOGGER_* ]]
+   then
+      echo "Processing ENV Log4J logger key ${key} with value ${value}"
+
+      setInPropertiesFile ${TOMCAT_DIR}/shared/classes/alfresco/extension/custom-log4j.properties "log4j.logger.${key}" ${value}
+
+   elif [[ $i == LOG4J-ADDITIVITY_* ]]
+   then
+      echo "Processing ENV Log4J additivity key ${key} with value ${value}"
+
+      setInPropertiesFile ${TOMCAT_DIR}/shared/classes/alfresco/extension/custom-log4j.properties "log4j.additivity.${key}" ${value}
+   fi
+done
+
+bash -c "$@"


### PR DESCRIPTION
This PR introduces an entrypoint script to support more fine grained configuration of Alfresco global properties and also Log4J. This allows users / customers to configure an instance of the Repository with easily managable, bite-sized environment variables.

An example docker-compose.yml using this feature would look like this:
```
version: '3.3'

services:
    repository01:
        image: alfresco/alfresco-content-repository-community:latest
        # ... various options like ports ... #
        environment:
          # JAVA_OPTS still relevant for JVM config
          - JAVA_OPTS=-Xms2g -Xmx2g -XX:+UseG1GC -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -XX:+ScavengeBeforeFullGC
          - GLOBAL_db.driver=org.postgresql.Driver
          - GLOBAL_db.username=my-custom-user
          - GLOBAL_db.password_FILE=/secrets/alfresco-database-password
          - GLOBAL_db.url=jdbc:postgresql://my-postgres.local:5432/my-alfresco-db
          - LOG4J-LOGGER_com.acme=DEBUG
        volumes:
          - ./alfresco-database-password:/secrets/alfresco-database-password:ro
        # ... other mounts ... #
```

Additionally, this support also covers corner cases previously not supported:

- setting any properties not pre-defined in any alfresco-global.properties / subsystem default configuration files (e.g. for legacy transformer config or composite properties, i.e. IMAP mount points)
- setting sensitive configuration values via mounted files / secrets