### PR TITLE
REPO-4739 update dependencies of tas framework (#776)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,8 +111,8 @@
         <dependency.rest-assured.version>3.3.0</dependency.rest-assured.version>
         <dependency.javax.json.version>1.1.4</dependency.javax.json.version>
         <dependency.tas-restapi.version>1.26</dependency.tas-restapi.version>
-        <dependency.tas-cmis.version>1.6</dependency.tas-cmis.version>
-        <dependency.tas-email.version>1.1</dependency.tas-email.version>
+        <dependency.tas-cmis.version>1.12</dependency.tas-cmis.version>
+        <dependency.tas-email.version>1.7</dependency.tas-email.version>
         <dependency.tas-webdav.version>1.4</dependency.tas-webdav.version>
         <dependency.tas-ftp.version>1.4</dependency.tas-ftp.version>
         <dependency.tas-dataprep.version>2.3</dependency.tas-dataprep.version>

--- a/tests/tas-cmis/src/test/java/org/alfresco/cmis/RepositoryInfoTests.java
+++ b/tests/tas-cmis/src/test/java/org/alfresco/cmis/RepositoryInfoTests.java
@@ -9,6 +9,7 @@ import org.apache.chemistry.opencmis.commons.data.AclCapabilities;
 import org.apache.chemistry.opencmis.commons.data.RepositoryCapabilities;
 import org.apache.chemistry.opencmis.commons.data.RepositoryInfo;
 import org.apache.chemistry.opencmis.commons.enums.BindingType;
+import org.apache.chemistry.opencmis.commons.exceptions.CmisConnectionException;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisRuntimeException;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisUnauthorizedException;
 import org.testng.Assert;
@@ -89,7 +90,7 @@ public class RepositoryInfoTests extends CmisTest
         cmisApi.authenticateUser(invalidUser).getRepositoryInfo();
     }
     
-    @Test(groups = { TestGroup.REGRESSION, TestGroup.CMIS}, expectedExceptions = {NoSuchMethodError.class}, expectedExceptionsMessageRegExp = "^org.apache.chemistry.opencmis.commons.exceptions.CmisConnectionException.*")
+    @Test(groups = { TestGroup.REGRESSION, TestGroup.CMIS}, expectedExceptions = {CmisConnectionException.class})
     @TestRail(section = { "cmis-api" }, executionType = ExecutionType.REGRESSION, description = "Verify that invalid user cannot get repositories")
     public void userCannotGetRepositoriesUsingWrongBrowserUrl() throws Exception
     {

--- a/tests/tas-email/src/test/java/org/alfresco/email/imap/ImapCopyMessagesTests.java
+++ b/tests/tas-email/src/test/java/org/alfresco/email/imap/ImapCopyMessagesTests.java
@@ -94,7 +94,7 @@ public class ImapCopyMessagesTests extends EmailTest
     @TestRail(section = { TestGroup.PROTOCOLS, TestGroup.IMAP }, executionType = ExecutionType.REGRESSION,
             description = "Verify user cannot copy file via IMAP client to a location where you don't have permissions")
     @Test(groups = { TestGroup.PROTOCOLS, TestGroup.IMAP, TestGroup.CORE }, expectedExceptions = MessagingException.class,
-                                                                            expectedExceptionsMessageRegExp = ".*A4 NO APPEND failed. Can't append message - Permission denied.*")
+                                                                            expectedExceptionsMessageRegExp = ".*NO APPEND failed. Can't append message - Permission denied.*")
     public void userCannotCopyFileWhereNoPermissions() throws Exception
     {
         testFolder = dataContent.usingUser(testUser).usingSite(testSite).createFolder();


### PR DESCRIPTION
With Dependabot enabled on the following repos:
[alfresco-tas-restapi](https://github.com/Alfresco/alfresco-tas-restapi)
[alfresco-tas-cmis](https://github.com/Alfresco/alfresco-tas-cmis)
[alfresco-tas-ftp](https://github.com/Alfresco/alfresco-tas-ftp)
[alfresco-tas-email](https://github.com/Alfresco/alfresco-tas-email)
[alfresco-tas-webdav](https://github.com/Alfresco/alfresco-tas-webdav) 
Changes have been made, where required to fix broken tests.

Cherry-picked from [acs-packaging #776](https://github.com/Alfresco/acs-packaging/pull/776)