### PR TITLE
It is not enough to just include googledocs-repo.

### DIFF
--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -208,6 +208,14 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>org.alfresco.integrations</groupId>
+                                    <artifactId>alfresco-googledocs-share-community</artifactId>
+                                    <version>${alfresco.googledocs.version}</version>
+                                    <type>amp</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/amps</outputDirectory>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>


### PR DESCRIPTION
Hi

In docker-alfresco packaging, there is `googledocs-repo-community` but not `googledocs-share-community`.

https://github.com/Alfresco/acs-community-packaging/blob/e3774f6b4a6da56fda2c896a6e6eb8a61bed48ee/docker-alfresco/pom.xml#L205

I modified to add this.

How about this?