### PR TITLE
GOOGLEDOCS-461 : Remove old commons-lang lib from Repo AMP dependencies

### DIFF
--- a/distribution/src/main/resources/licenses/notice.txt
+++ b/distribution/src/main/resources/licenses/notice.txt
@@ -37,8 +37,7 @@ commons-fileupload  http://jakarta.apache.org/commons/
 commons-httpclient  http://jakarta.apache.org/commons/ 
 commons-io  http://jakarta.apache.org/commons/ 
 commons-jxpath  http://jakarta.apache.org/commons/ 
-commons-lang    http://jakarta.apache.org/commons/ 
-commons-lang3   http://jakarta.apache.org/commons/ 
+commons-lang3   http://jakarta.apache.org/commons/
 commons-logging http://jakarta.apache.org/commons/ 
 commons-net http://jakarta.apache.org/commons/
 commons-pool    http://jakarta.apache.org/commons/ 

--- a/pom.xml
+++ b/pom.xml
@@ -283,11 +283,6 @@
                 <version>2.1</version>
             </dependency>
             <dependency>
-                <groupId>commons-lang</groupId>
-                <artifactId>commons-lang</artifactId>
-                <version>2.6</version>
-            </dependency>
-            <dependency>
                 <groupId>commons-fileupload</groupId>
                 <artifactId>commons-fileupload</artifactId>
                 <version>1.4</version>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -95,12 +95,6 @@
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
-        <!-- required by GDocs-->
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>2.6</version>
-        </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>


### PR DESCRIPTION
   - remove workaround - no longer needed