### PR TITLE
REPO-4753: test acs-packaging build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
         <image.tag>latest</image.tag>
 
         <dependency.alfresco-remote-api.version>8.97</dependency.alfresco-remote-api.version>
-        <dependency.alfresco-repository.version>8.93</dependency.alfresco-repository.version>
+        <dependency.alfresco-repository.version>repo-4753-1</dependency.alfresco-repository.version>
         <dependency.alfresco-data-model.version>8.87</dependency.alfresco-data-model.version>
         <dependency.alfresco-core.version>8.21</dependency.alfresco-core.version>
 


### PR DESCRIPTION
Test the build of acs-packaging after the changes. The library com.googlecode.mp4parser.isoparser is not required in the alfresco-repository project and triggers some conflict issues in tika project.