### PR TITLE
REPO-5037 Fix fabric8 build error on Windows

### DIFF
--- a/docker-alfresco/Dockerfile
+++ b/docker-alfresco/Dockerfile
@@ -5,7 +5,7 @@ FROM alfresco/alfresco-base-tomcat:8.5.43-java-11-openjdk-centos-7
 # Set default user information
 ARG GROUPNAME=Alfresco
 ARG GROUPID=1000
-ARG USERNAME=alfresco
+ARG IMAGEUSERNAME=alfresco
 ARG USERID=33000
 
 # Set default environment args
@@ -73,7 +73,7 @@ RUN yum install -y fontconfig-2.13.0-4.3.el7 \
 RUN mkdir -p ${TOMCAT_DIR}/conf/Catalina/localhost && \
     mkdir -p ${TOMCAT_DIR}/alf_data && \
     groupadd -g ${GROUPID} ${GROUPNAME} && \
-    useradd -u ${USERID} -G ${GROUPNAME} ${USERNAME} && \
+    useradd -u ${USERID} -G ${GROUPNAME} ${IMAGEUSERNAME} && \
     chgrp -R ${GROUPNAME} ${TOMCAT_DIR} && \
     chmod g+w ${TOMCAT_DIR}/logs && \
     chmod g+rx ${TOMCAT_DIR}/conf && \
@@ -94,4 +94,4 @@ RUN mkdir -p ${TOMCAT_DIR}/conf/Catalina/localhost && \
 # Changes are also required to the docker-compose/docker-compose.yml file.
 # EXPOSE 8000
 
-USER ${USERNAME}
+USER ${IMAGEUSERNAME}


### PR DESCRIPTION
Since upgrading to fabric8-maven-plugin:4.x.x the docker image creation has failed on Windows. It appear that the variable USERNAME it cannot be set by the plugin and the current logged in user name is used instead. This is prevents the alfresco user being created correctly and also causes errors when trying to apply amps.
Renaming the variable fixes this issue.