### PR TITLE
REPO-5072: Update version of acs-packaging to 7.0

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-community-packaging</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-community-packaging</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
@@ -200,14 +200,14 @@
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
                                 </artifactItem>
-                                <artifactItem>
+<!--                                 <artifactItem>
                                     <groupId>org.alfresco.integrations</groupId>
                                     <artifactId>alfresco-googledrive-repo-community</artifactId>
                                     <version>${alfresco.googledrive.version}</version>
                                     <type>amp</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/amps</outputDirectory>
-                                </artifactItem>
+                                </artifactItem> -->
                             </artifactItems>
                         </configuration>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <artifactId>acs-community-packaging</artifactId>
     <name>Alfresco Content Services Community Packaging</name>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>7.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>

--- a/public-javadoc/pom.xml
+++ b/public-javadoc/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-community-packaging</artifactId>
-	<version>6.3.0-SNAPSHOT</version>
+	<version>7.0-SNAPSHOT</version>
 	<relativePath>../pom.xml</relativePath>
     </parent>
     <packaging>pom</packaging>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -1,13 +1,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <artifactId>content-repository-community-tas-tests-parent</artifactId>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>7.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-community-packaging</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/tas-cmis/pom.xml
+++ b/tests/tas-cmis/pom.xml
@@ -4,13 +4,13 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>content-repository-community-cmis-test</artifactId>
     <name>content-repository-community-cmis-test</name>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-community-tas-tests-parent</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/tas-email/pom.xml
+++ b/tests/tas-email/pom.xml
@@ -4,13 +4,13 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>content-repository-community-email-test</artifactId>
     <name>content-repository-community-email-test</name>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-community-tas-tests-parent</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/tas-integration/pom.xml
+++ b/tests/tas-integration/pom.xml
@@ -4,13 +4,13 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>content-repository-community-integration-test</artifactId>
     <name>content-repository-community-integration-test</name>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-community-tas-tests-parent</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/tas-restapi/pom.xml
+++ b/tests/tas-restapi/pom.xml
@@ -4,13 +4,13 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>content-repository-community-restapi-test</artifactId>
     <name>content-repository-community-restapi-test</name>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-community-tas-tests-parent</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tests/tas-webdav/pom.xml
+++ b/tests/tas-webdav/pom.xml
@@ -4,13 +4,13 @@
     <groupId>org.alfresco.tas</groupId>
     <artifactId>content-repository-community-webdav-test</artifactId>
     <name>content-repository-community-webdav-test</name>
-    <version>6.3.0-SNAPSHOT</version>
+    <version>7.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>content-repository-community-tas-tests-parent</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.alfresco</groupId>
         <artifactId>acs-community-packaging</artifactId>
-        <version>6.3.0-SNAPSHOT</version>
+        <version>7.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
- update version to 7.0-SNAPSHOT
- comment out googledrive-repo-community amp since it is not compatible with the new acs-community version
- changes required on amps will be done in https://issues.alfresco.com/jira/browse/REPO-5086