### PR TITLE
ACS-896 Fix community PR builds

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -15,7 +15,7 @@
                         <enabled>true</enabled>
                     </snapshots>
                     <name>Alfresco Internal Repository</name>
-                    <url>https://artifacts.alfresco.com/nexus/content/groups/internal</url>
+                    <url>https://artifacts.alfresco.com/nexus/content/groups/public</url>
                 </repository>
             </repositories>
             <pluginRepositories>
@@ -32,22 +32,11 @@
         </profile>
     </profiles>
 
-
     <servers>
         <server>
             <id>alfresco-internal</id>
             <username>${env.MAVEN_USERNAME}</username>
             <password>${env.MAVEN_PASSWORD}</password>
-        </server>
-        <server>
-            <id>quay.io</id>
-            <username>${env.QUAY_USERNAME}</username>
-            <password>${env.QUAY_PASSWORD}</password>
-        </server>
-        <server>
-            <id>docker.io</id>
-            <username>${env.DOCKERHUB_USERNAME}</username>
-            <password>${env.DOCKERHUB_PASSWORD}</password>
         </server>
     </servers>
 </settings>

--- a/scripts/travis/init.sh
+++ b/scripts/travis/init.sh
@@ -9,8 +9,10 @@ mkdir -p "${HOME}/.m2" && cp -f .travis.settings.xml "${HOME}/.m2/settings.xml"
 find "${HOME}/.m2/repository/" -type d -name "*-SNAPSHOT*" | xargs -r -l rm -rf
 
 # Docker Logins
-echo "${DOCKERHUB_PASSWORD}" | docker login -u="${DOCKERHUB_USERNAME}" --password-stdin
-echo "${QUAY_PASSWORD}" | docker login -u="${QUAY_USERNAME}" --password-stdin quay.io
+if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  echo "${DOCKERHUB_PASSWORD}" | docker login -u="${DOCKERHUB_USERNAME}" --password-stdin
+  echo "${QUAY_PASSWORD}" | docker login -u="${QUAY_USERNAME}" --password-stdin quay.io
+fi
 
 # Enable experimental docker features (for the image squash option)
 echo '{"experimental":true}' | sudo tee /etc/docker/daemon.json


### PR DESCRIPTION
- **scripts/travis/init.sh**: execute the docker logins only on branch builds
- **~/.m2/settings.xml**: remove `quay.io` & `docker.io` server definitions
  (the docker logins in the init.sh script should be enough)