### PR TITLE
ACS-960 Disable very frequent intermittent test failures

### DIFF
--- a/tests/tas-email/src/test/java/org/alfresco/email/imap/ImapReadMessagesAcsTests.java
+++ b/tests/tas-email/src/test/java/org/alfresco/email/imap/ImapReadMessagesAcsTests.java
@@ -24,6 +24,7 @@ public class ImapReadMessagesAcsTests extends EmailTest
     public void siteManagerCanViewWikiPages() throws Exception
     {
         dataWiki.usingUser(testUser).usingSite(testSite).createRandomWiki();
+        /* @Category(IntermittentlyFailingTests.class) ACS-959 Intermittent failure on next line. @Category not supported by TAS tests. */
         imapProtocol.authenticateUser(testUser).usingSiteWikiContainer(testSite).assertThat().countMessagesIs(1);
     }
 }


### PR DESCRIPTION
Part of Epic: ACS-959 Fix or suppress the content repository's intermittent test failures