### PR TITLE
ACS-946 exclude meta-info folder from distribution

### DIFF
--- a/distribution/src/assembly/distribution.xml
+++ b/distribution/src/assembly/distribution.xml
@@ -13,6 +13,9 @@
         <fileSet>
             <directory>target/classes</directory>
             <outputDirectory></outputDirectory>
+            <excludes>
+                <exclude>META-INF/**</exclude>
+            </excludes>
         </fileSet>
         <!-- Licenses -->
         <fileSet>


### PR DESCRIPTION
https://alfresco.atlassian.net/browse/ACS-946

Fix to exclude META-INFO folder from the zip distribution