### PR TITLE
APPS-1068 Enable docker updates for AGS latest images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,7 +121,7 @@ jobs:
 
     - name: "Update latest images"
       stage: docker_latest
-      script: travis_retry travis_wait 30 mvn -B -V clean install -DskipTests -Dmaven.javadoc.skip=true -Ppush-docker-images
+      script: travis_retry travis_wait 30 mvn -B -V clean install -DskipTests -Dmaven.javadoc.skip=true -Pags -Ppush-docker-images
 
     - name: "Release and Copy to S3 Staging Bucket"
       stage: release


### PR DESCRIPTION
Enable the updating of AGS-specific images with the tag `latest` from the **master** branch (on Quay only):
* `quay.io/alfresco/alfresco-governance-repository-community`
* `quay.io/alfresco/alfresco-governance-share-community`

Access rights need to be granted to the Quay user on these two images.