### PR TITLE
Fix community build outside of Alfresco

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,31 @@
         </snapshotRepository>
     </distributionManagement>
 
+    <repositories>
+        <repository>
+            <id>alfresco-public</id>
+            <url>https://artifacts.alfresco.com/nexus/content/groups/public</url>
+            <releases>
+                <enabled>true</enabled>
+            </releases>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
+            <id>alfresco-public-snapshots</id>
+            <url>https://artifacts.alfresco.com/nexus/content/groups/public-snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <modules>
         <module>distribution</module>
-        <module>public-javadoc</module>
         <module>docker-alfresco</module>
         <module>docker-share</module>
     </modules>
@@ -64,6 +86,7 @@
         <profile>
             <id>release</id>
             <modules>
+                <module>public-javadoc</module>
                 <module>dev</module>
             </modules>
         </profile>


### PR DESCRIPTION
Enable a plain vanilla machine without access to Alfresco internal artifacts to build ACS community