### PR TITLE
Fix broken 'envUp' alias

### DIFF
--- a/dev/aliases
+++ b/dev/aliases
@@ -64,7 +64,7 @@ alias comXS='comS  && comP'
 # Clean up of docker images and content stores (alf_data directories)
 alias     drm='docker rm -f $(docker ps -q)'
 alias     arm='rm -rf `find . -name alf_data`'
-alias   envUp='docker-compose -f acs-community-packaging/scripts/dev/start-compose.sh'
+alias   envUp='./acs-community-packaging/scripts/dev/start-compose.sh'
 alias envStop='docker-compose -f acs-community-packaging/dev/docker-compose.yml stop'
 alias envKill='docker-compose -f acs-community-packaging/dev/docker-compose.yml kill'
 alias   envRm='docker-compose -f acs-community-packaging/dev/docker-compose.yml rm'

--- a/scripts/dev/start-compose.sh
+++ b/scripts/dev/start-compose.sh
@@ -1,5 +1,5 @@
 set -x
-export TRANSFORMERS_TAG=$(mvn help:evaluate -Dexpression=dependency.alfresco-transform-core.version -q -DforceStdout)
+export TRANSFORMERS_TAG=$(mvn -f acs-community-packaging/pom.xml help:evaluate -Dexpression=dependency.alfresco-transform-core.version -q -DforceStdout)
 
 # .env files are picked up from project directory correctly on docker-compose 1.23.0+
-docker-compose -f acs-packaging/dev/docker-compose.yml up
+docker-compose -f acs-community-packaging/dev/docker-compose.yml up


### PR DESCRIPTION
The `envUp` alias was malformed, referring to `acs-packaging` instead of `acs-community-packaging`, and unusable from the parent directory as opposed to the previous behaviour _(documented [here](https://github.com/Alfresco/acs-community-packaging/blob/master/dev/README.md?plain=1#L68-L71))_. This PR fixes the alias and restores the original behaviour.