### PR TITLE
ACS-3347 Upgrade to Java 17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 dist: xenial
 language: java
-jdk: openjdk11
+jdk: openjdk17
 
 services:
   - docker

--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
     </parent>
 
     <properties>
-        <dependency.alfresco-community-repo.version>17.50</dependency.alfresco-community-repo.version>
-        <dependency.alfresco-community-share.version>17.46</dependency.alfresco-community-share.version>
+        <dependency.alfresco-community-repo.version>17.58-SNAPSHOT</dependency.alfresco-community-repo.version>
+        <dependency.alfresco-community-share.version>17.49-SNAPSHOT</dependency.alfresco-community-share.version>
         <dependency.acs-packaging.version>7.3.0-M2</dependency.acs-packaging.version> <!-- for Share distribution zip -->
 
         <repo.image.tag>${dependency.alfresco-community-repo.version}</repo.image.tag>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <groupId>org.alfresco</groupId>
         <artifactId>alfresco-community-repo</artifactId>
         <relativePath>../alfresco-community-repo/pom.xml</relativePath>
-        <version>17.50</version>
+        <version>17.58-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/scripts/travis/build.sh
+++ b/scripts/travis/build.sh
@@ -53,7 +53,14 @@ if [[ "${SHARE_DEPENDENCY_VERSION}" =~ ^.+-SNAPSHOT$ ]] && [ "${TRAVIS_BUILD_STA
 fi
 
 SHARE_UPSTREAM_REPO="github.com/Alfresco/alfresco-community-share.git"
-
+# Temporarily opening reflective access during compilation for community-share
+# This could be removed once community-share will become Java 17 compliant
+# (Maven plugins included e.g.: maven-war-plugin)
+export MAVEN_OPTS="--add-opens=java.base/java.util=ALL-UNNAMED \
+--add-opens=java.base/java.lang=ALL-UNNAMED \
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+--add-opens=java.base/java.text=ALL-UNNAMED \
+--add-opens=java.desktop/java.awt.font=ALL-UNNAMED"
 # Checkout the upstream share project (tag or branch; + build if the latter)
 if [[ "${SHARE_DEPENDENCY_VERSION}" =~ ^.+-SNAPSHOT$ ]] ; then
   pullAndBuildSameBranchOnUpstream "${SHARE_UPSTREAM_REPO}" "-Pbuild-docker-images -Pags -Dlicense.failOnNotUptodateHeader=true -Ddocker.quay-expires.value=NEVER ${REPO_IMAGE} -Ddependency.alfresco-community-repo.version=${COM_DEPENDENCY_VERSION}"

--- a/tests/tas-integration/pom.xml
+++ b/tests/tas-integration/pom.xml
@@ -114,8 +114,10 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
+                    <!-- Keeping illegal-access=warn for Java 11 compatibility, even though it has no effect on JDK 17 -->
                     <argLine>
                         --illegal-access=warn
+                        --add-opens=java.base/java.lang=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>

--- a/tests/tas-restapi/pom.xml
+++ b/tests/tas-restapi/pom.xml
@@ -84,8 +84,10 @@
                     <suiteXmlFiles>
                         <suiteXmlFile>${suiteXmlFile}</suiteXmlFile>
                     </suiteXmlFiles>
+                    <!-- Keeping illegal-access=warn for Java 11 compatibility, even though it has no effect on JDK 17 -->
                     <argLine>
                         --illegal-access=warn
+                        --add-opens=java.base/java.lang=ALL-UNNAMED
                     </argLine>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Upgrade Travis runtime to Java 17.
This needs https://github.com/Alfresco/alfresco-enterprise-share/pull/261 to be merged and propagated to https://github.com/Alfresco/alfresco-community-share.