### PR TITLE
ACS-4063 Remove provenance layer to address PROJQUAY-5013

### DIFF
--- a/docker-alfresco/pom.xml
+++ b/docker-alfresco/pom.xml
@@ -119,6 +119,9 @@
                                                 <platform>linux/amd64</platform>
                                                 <platform>linux/arm64</platform>
                                             </platforms>
+                                            <attestations>
+                                                <provenance>false</provenance>
+                                            </attestations>
                                         </buildx>
                                         <dockerFileDir>${project.basedir}</dockerFileDir>
                                         <args>
@@ -185,6 +188,9 @@
                                                 <platform>linux/amd64</platform>
                                                 <platform>linux/arm64</platform>
                                             </platforms>
+                                            <attestations>
+                                                <provenance>false</provenance>
+                                            </attestations>
                                         </buildx>
                                         <dockerFileDir>${project.basedir}</dockerFileDir>
                                         <args>
@@ -255,6 +261,9 @@
                                                         <platform>linux/amd64</platform>
                                                         <platform>linux/arm64</platform>
                                                     </platforms>
+                                                    <attestations>
+                                                        <provenance>false</provenance>
+                                                    </attestations>
                                                 </buildx>
                                                 <dockerFileDir>${project.basedir}</dockerFileDir>
                                                 <args>
@@ -284,6 +293,9 @@
                                                         <platform>linux/amd64</platform>
                                                         <platform>linux/arm64</platform>
                                                     </platforms>
+                                                    <attestations>
+                                                        <provenance>false</provenance>
+                                                    </attestations>
                                                 </buildx>
                                                 <dockerFileDir>${project.basedir}</dockerFileDir>
                                                 <args>

--- a/docker-share/ags/pom.xml
+++ b/docker-share/ags/pom.xml
@@ -101,6 +101,9 @@
                                     <platform>linux/amd64</platform>
                                     <platform>linux/arm64</platform>
                                  </platforms>
+                                 <attestations>
+                                    <provenance>false</provenance>
+                                 </attestations>
                               </buildx>
                               <dockerFileDir>${project.basedir}</dockerFileDir>
                               <args>
@@ -167,6 +170,9 @@
                                     <platform>linux/amd64</platform>
                                     <platform>linux/arm64</platform>
                                  </platforms>
+                                 <attestations>
+                                    <provenance>false</provenance>
+                                 </attestations>
                               </buildx>
                               <dockerFileDir>${project.basedir}</dockerFileDir>
                               <args>
@@ -237,6 +243,9 @@
                                           <platform>linux/amd64</platform>
                                           <platform>linux/arm64</platform>
                                        </platforms>
+                                       <attestations>
+                                          <provenance>false</provenance>
+                                       </attestations>
                                     </buildx>
                                     <dockerFileDir>${project.basedir}</dockerFileDir>
                                     <args>
@@ -266,6 +275,9 @@
                                           <platform>linux/amd64</platform>
                                           <platform>linux/arm64</platform>
                                        </platforms>
+                                       <attestations>
+                                          <provenance>false</provenance>
+                                       </attestations>
                                     </buildx>
                                     <dockerFileDir>${project.basedir}</dockerFileDir>
                                     <args>


### PR DESCRIPTION
Removing the provenance layer since it causes issues with the manifest and labels parsing and rendering on the quay.io UI.