### PR TITLE
README update of Tomcat environment setup.

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -1,11 +1,14 @@
 # Development Tomcat Environment
 
-It is possible to use Docker containers to test your code, but it is normally more convenient to simply run the repository webapp (**`alfresco.war`**) and Share webapp (**`share.war`**) in a tomcat instance. Options are also available to apply selected AMPs.
 
-## 1. Setting up your development environment
+It is possible to use Docker containers to test your code, but it is normally more convenient to simply run the
+repository webapp (`alfresco.war`) and Share webapp (`share.war`) in a tomcat instance. Options are also available to
+apply selected AMPs.
+
+## Setting up your development environment
 Although it is possible to work on individual github projects, we recommend working on
 the `alfresco-community-repo`, `alfresco-community-share` and `acs-community-packaging`
-in a single Intellij IDEA project. They depend on each other and typically you 
+in a single Intellij IDEA project. They depend on each other and typically you
 will want to make changes to all of them if you are changing the repository code.
 
 ~~~bash
@@ -16,27 +19,30 @@ git clone git@github.com:Alfresco/alfresco-community-share.git
 git clone git@github.com:Alfresco/acs-community-packaging.git
 ~~~
 
-## 2. Aliases
-There are a set of aliases to help with building. You may find them useful, as they will help you only build selected parts of the code base and will save you lots of typing.
+## Aliases
+There are a set of aliases to help with building. You may find them useful, as they will help you only build selected parts
+of the code base and will save you lots of typing.
 
-Aliases ending in **`D`** provide Maven commands for building local Docker images. The AMPS environment variable will be of interest, if you wish to build AMPs included in the repo and share projects. 
+Aliases ending in `D` provide Maven commands for building local Docker images. The AMPS environment variable will be of
+interest, if you wish to build AMPs included in the repo and share projects.
 
-**You may also build **`alfresco-community-repository`**, **`alfresco-community-share`** and **`alfresco-community-packaging`** with Docker images at once with **`comD`**.**  
-
-The **`aliases`** file includes a more detailed description.
+The `aliases` file includes a more detailed description.
 ~~~bash
 source acs-community-packaging/dev/aliases
 ~~~
 
 ## Link the projects
-Generally you will want to link the different projects together by modifying the top level pom.xml files of each downstream project so that they reference the SNAPSHOT versions of the upstream projects. To help do this see the **`acs-community-packaging`** project's **`scripts/dev/linkPoms.sh`** and **`scripts/dev/unlinkPoms.sh`** scripts.
+Generally you will want to link the different projects together by modifying the top level
+pom.xml files of each downstream project so that they reference the SNAPSHOT versions of the
+upstream projects. To help do this see the `acs-community-packaging` project's `scripts/dev/linkPoms.sh` and
+`scripts/dev/unlinkPoms.sh` scripts.
 
 ~~~bash
 sh acs-community-packaging/scripts/dev/linkPoms.sh
 ~~~
 
-## 3. Build the Repo project
-Build the `alfresco-community-repo` projects with **`comR`**, so that your changes are in the community alfresco.war file.
+## Build the alfresco-community-repo project
+Build the `alfresco-community-repo` projects, so that your changes are in the community alfresco.war file.
 ~~~bash
 # The `comR` alias includes the following commands:
 cd alfresco-community-repo
@@ -44,8 +50,9 @@ mvn clean install -DskipTests=true -Dversion.edition=Community
 cd ..
 ~~~
 
-## 4. Build the Share project
-Build the `alfresco-community-share` project with **`comS`**, so that your changes are in the community share.war file, which also depends on your **`alfresco-community-repo`** project version.
+## Build the Share project
+Build the `alfresco-community-share` project, so that your changes are in 
+the community share.war file, which also depends on your `alfresco-community-repo` project version.
 ~~~bash
 # The `comS` alias is the same as the following commands:
 cd alfresco-community-share
@@ -53,11 +60,12 @@ mvn clean install -DskipTests -Dmaven.javadoc.skip=true
 cd ..
 ~~~
 
-## 5. Docker test environment
-The repository code will need to talk to other ACS components, such as a database, message queue and transformers. The simplest way to create these, is to use the **`docker-compose.yml`** file in the **`dev`** directory. Do it with **`envUp`** alias.
+## Docker test environment
+The repository code will need to talk to other ACS components, such as a database, message queue and transformers.
+The simplest way to create these, is to use the `docker-compose.yml` file in the `dev` directory.
 ~~~bash
 # The `envUp` alias is the same as the following commands. Run these in a new terminal session, or add a `-d` flag to
-the `docker compose` command.
+# the `docker compose` command.
 cd acs-community-packaging
 docker compose -f dev/docker-compose.yml up
 Creating dev_activemq_1           ... done
@@ -69,15 +77,20 @@ cd ..
 ~~~
 
 ## Alfresco global properties and Log4j
-Set any alfresco-global.properties or log4j properties you may need in the following files. They will be copied to the `dev/dev-acs-amps-overlay/target` directory. Other customisations may also be placed in the `extension` directory. 
-~~~bash
+Set any alfresco-global.properties or log4j properties you may need in the following files. They will be copied
+to the `dev/dev-acs-amps-overlay/target` directory. Other customisations may also be placed in the `extension` directory.
+~~~
 dev/dev-tomcat/src/main/tomcat/shared/classes/alfresco/extension/custom-log4j2.properties
 dev/dev-tomcat/src/main/tomcat/shared/classes/alfresco-global.properties
 ~~~
 
-## 6. Tomcat
+## Tomcat
 Create the development tomcat environment, apply AMPs on top of the repository code, and
-run tomcat. The `run` profile is what starts tomcat. The `withShare` applies the Share services AMP and adds the `share.war` to tomcat. Once started, you will be able to access Share on **`http://localhost:8080/share`** and various repository endpoints via **`http://localhost:8080/alfresco/`**. **`comT`** is an alias for the following command and **`comTDebug`** will allow a debugger to be attached.
+run tomcat. The `run` profile is what starts tomcat. The `withShare` applies
+the Share services AMP and adds the `share.war` to tomcat.
+Once started, you will be able to access Share on `http://localhost:8080/share` and various repository
+endpoints via `http://localhost:8080/alfresco/`. `comT` is an alias for the
+following command and `comTDebug` will allow a debugger to be attached.
 ~~~bash
 # The alias comT is the same as the following commands:
 cd acs-community-packaging
@@ -96,14 +109,18 @@ INFO: Starting ProtocolHandler ["http-bio-8080"]
 cd ..
 ~~~
 
-If you kill the tomcat instance (^C) and wish to restart it, use the following command or the **`comO`** alias, or **`comODebug`** to attach a debugger.
+If you kill the tomcat instance (^C) and wish to restart it, use the following command
+or the `comO` alias, or `comODebug` to attach a debugger.
 ~~~bash
 mvn install -Prun,withShare -rf dev-acs-amps-overlay
 ~~~
 
 
-## 7. Clean up
-When finished, kill the tomcat instance and stop the Docker instances. You will normally also remove the Docker containers, as you will need a clean database if you are going to issue another `mvn clean install` command. If you started `docker compose` in a separate terminal session, simply use `^C` or if you used a `-d` flag, use `docker compose -f dev/docker-compose.yml stop`.
+## Clean up
+When finished, kill the tomcat instance and stop the Docker instances. You will normally also
+remove the Docker containers, as you will need a clean database if you are going to issue
+another `mvn clean install` command. If you started `docker compose` in a separate terminal session,
+simply use `^C` or if you used a `-d` flag, use `docker compose -f dev/docker-compose.yml stop`.
 ~~~bash
 ^C
 ... Stopped 'sysAdmin' subsystem, ID: [sysAdmin, default]
@@ -117,10 +134,13 @@ Removing dev_postgres_1           ... done
 Removing dev_activemq_1           ... done
 ~~~
 
-If you have not removed the containers, it is possible to restart the tomcat instance with a `mvn install` (no `clean`), but this may result in failures if there are incompatibilities between the code, database and content in `dev/dev-acs-amps-overlay/target/dev-instance/runtime/alf_data`.
-
+If you have not removed the containers, it is possible to restart the tomcat instance with
+a `mvn install` (no `clean`), but this may result in failures if there are incompatibilities
+between the code, database and content in `dev/dev-acs-amps-overlay/target/dev-instance/runtime/alf_data`.
 Any changes made to alfresco-global properties or log4j will not be picked up, unless you
-directly edit `dev/dev-acs-amps-overlay/target/dev-instance/tomcat/shared/classes/alfresco/extension/custom-log4j2.properties` and `dev/dev-acs-amps-overlay/target/dev-instance/tomcat/shared/classes/alfresco-global.properties`, but they will be thrown away on the next `mvn clean`.
+directly edit `dev/dev-acs-amps-overlay/target/dev-instance/tomcat/shared/classes/alfresco/extension/custom-log4j2.properties`
+and `dev/dev-acs-amps-overlay/target/dev-instance/tomcat/shared/classes/alfresco-global.properties`, but they will be thrown away
+on the next `mvn clean`.
 
 ## Helpful links
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -41,7 +41,7 @@ upstream projects. To help do this see the `acs-community-packaging` project's `
 sh acs-community-packaging/scripts/dev/linkPoms.sh
 ~~~
 
-## Build the alfresco-community-repo project
+## Build the Repo project
 Build the `alfresco-community-repo` projects, so that your changes are in the community alfresco.war file.
 ~~~bash
 # The `comR` alias includes the following commands:

--- a/dev/README.md
+++ b/dev/README.md
@@ -1,17 +1,14 @@
 # Development Tomcat Environment
 
+It is possible to use Docker containers to test your code, but it is normally more convenient to simply run the repository webapp (**`alfresco.war`**) and Share webapp (**`share.war`**) in a tomcat instance. Options are also available to apply selected AMPs.
 
-It is possible to use Docker containers to test your code, but it is normally more convenient to simply run the
-repository webapp (`alfresco.war`) and Share webapp (`share.war`) in a tomcat instance. Options are also available to
-apply selected AMPs
-
-## Setting up your development environment
+## 1. Setting up your development environment
 Although it is possible to work on individual github projects, we recommend working on
 the `alfresco-community-repo`, `alfresco-community-share` and `acs-community-packaging`
 in a single Intellij IDEA project. They depend on each other and typically you 
 will want to make changes to all of them if you are changing the repository code.
 
-~~~
+~~~bash
 mkdir work
 cd work
 git clone git@github.com:Alfresco/alfresco-community-repo.git
@@ -19,52 +16,46 @@ git clone git@github.com:Alfresco/alfresco-community-share.git
 git clone git@github.com:Alfresco/acs-community-packaging.git
 ~~~
 
-## Aliases
-There are a set of aliases to help with building. You may find them useful, as they will help you only build selected parts
-of the code base and will save you lots of typing.
+## 2. Aliases
+There are a set of aliases to help with building. You may find them useful, as they will help you only build selected parts of the code base and will save you lots of typing.
 
-Aliases ending in `D` provide Maven commands for building local Docker images. The AMPS environment variable will be of
-interest, if you wish to build AMPs included in the repo and share projects. 
+Aliases ending in **`D`** provide Maven commands for building local Docker images. The AMPS environment variable will be of interest, if you wish to build AMPs included in the repo and share projects. 
 
-The `aliases` file includes a more detailed description.
-~~~
+**You may also build **`alfresco-community-repository`**, **`alfresco-community-share`** and **`alfresco-community-packaging`** with Docker images at once with **`comD`**.**  
+
+The **`aliases`** file includes a more detailed description.
+~~~bash
 source acs-community-packaging/dev/aliases
 ~~~
 
 ## Link the projects
-Generally you will want to link the different projects together by modifying the top level
-pom.xml files of each downstream project so that they reference the SNAPSHOT versions of the
-upstream projects. To help do this see the `acs-community-packaging` project's `scripts/dev/linkPoms.sh` and
-`scripts/dev/unlinkPoms.sh` scripts.
+Generally you will want to link the different projects together by modifying the top level pom.xml files of each downstream project so that they reference the SNAPSHOT versions of the upstream projects. To help do this see the **`acs-community-packaging`** project's **`scripts/dev/linkPoms.sh`** and **`scripts/dev/unlinkPoms.sh`** scripts.
 
-~~~
+~~~bash
 sh acs-community-packaging/scripts/dev/linkPoms.sh
 ~~~
 
-## Build the alfresco-community-repo project
-Build the `alfresco-community-repo` projects (if you have not
-done so already), so that your changes are in the community alfresco.war file.
-~~~
+## 3. Build the Repo project
+Build the `alfresco-community-repo` projects with **`comR`**, so that your changes are in the community alfresco.war file.
+~~~bash
 # The `comR` alias includes the following commands:
 cd alfresco-community-repo
 mvn clean install -DskipTests=true -Dversion.edition=Community
 cd ..
 ~~~
 
-## Build the Share project
-Build the `alfresco-community-share` project (if you have not done so already), so that your
-changes are in the community share.war file, which also depends on your `alfresco-community-repo` project version.
-~~~
-# The `entS` alias is the same as the following commands:
+## 4. Build the Share project
+Build the `alfresco-community-share` project with **`comS`**, so that your changes are in the community share.war file, which also depends on your **`alfresco-community-repo`** project version.
+~~~bash
+# The `comS` alias is the same as the following commands:
 cd alfresco-community-share
 mvn clean install -DskipTests -Dmaven.javadoc.skip=true
 cd ..
 ~~~
 
-## Docker test environment
-The repository code will need to talk to other ACS components, such as a database, message queue and transformers.
-The simplest way to create these, is to use the `docker-compose.yml` file in the `dev` directory.
-~~~
+## 5. Docker test environment
+The repository code will need to talk to other ACS components, such as a database, message queue and transformers. The simplest way to create these, is to use the **`docker-compose.yml`** file in the **`dev`** directory. Do it with **`envUp`** alias.
+~~~bash
 # The `envUp` alias is the same as the following commands. Run these in a new terminal session, or add a `-d` flag to
 the `docker compose` command.
 cd acs-community-packaging
@@ -78,21 +69,16 @@ cd ..
 ~~~
 
 ## Alfresco global properties and Log4j
-Set any alfresco-global.properties or log4j properties you may need in the following files. They will be copied
-to the `dev/dev-acs-amps-overlay/target` directory. Other customisations may also be placed in the `extension` directory. 
-~~~
+Set any alfresco-global.properties or log4j properties you may need in the following files. They will be copied to the `dev/dev-acs-amps-overlay/target` directory. Other customisations may also be placed in the `extension` directory. 
+~~~bash
 dev/dev-tomcat/src/main/tomcat/shared/classes/alfresco/extension/custom-log4j2.properties
 dev/dev-tomcat/src/main/tomcat/shared/classes/alfresco-global.properties
 ~~~
 
-## Tomcat
+## 6. Tomcat
 Create the development tomcat environment, apply AMPs on top of the repository code, and
-run tomcat. The `run` profile is what starts tomcat. The `withShare` applies
-the Share services AMP and adds the `share.war` to tomcat. 
-Once started, you will be able to access Share on `http://localhost:8080/share` and various repository
-endpoints via `http://localhost:8080/alfresco/`. `comT` is an alias for the
-following command and `comTDebug` will allow a debugger to be attached.
-~~~
+run tomcat. The `run` profile is what starts tomcat. The `withShare` applies the Share services AMP and adds the `share.war` to tomcat. Once started, you will be able to access Share on **`http://localhost:8080/share`** and various repository endpoints via **`http://localhost:8080/alfresco/`**. **`comT`** is an alias for the following command and **`comTDebug`** will allow a debugger to be attached.
+~~~bash
 # The alias comT is the same as the following commands:
 cd acs-community-packaging
 mvn clean install -Prun -rf dev
@@ -110,19 +96,15 @@ INFO: Starting ProtocolHandler ["http-bio-8080"]
 cd ..
 ~~~
 
-If you kill the tomcat instance (^C) and wish to restart it, use the following command
-or the `comO` alias, or `comODebug` to attach a debugger.
-~~~
+If you kill the tomcat instance (^C) and wish to restart it, use the following command or the **`comO`** alias, or **`comODebug`** to attach a debugger.
+~~~bash
 mvn install -Prun,withShare -rf dev-acs-amps-overlay
 ~~~
 
 
-## Clean up
-When finished, kill the tomcat instance and stop the Docker instances. You will normally also
-remove the Docker containers, as you will need a clean database if you are going to issue
-another `mvn clean install` command. If you started `docker compose` in a separate terminal session,
-simply use `^C` or if you used a `-d` flag, use `docker compose -f dev/docker-compose.yml stop`.
-~~~
+## 7. Clean up
+When finished, kill the tomcat instance and stop the Docker instances. You will normally also remove the Docker containers, as you will need a clean database if you are going to issue another `mvn clean install` command. If you started `docker compose` in a separate terminal session, simply use `^C` or if you used a `-d` flag, use `docker compose -f dev/docker-compose.yml stop`.
+~~~bash
 ^C
 ... Stopped 'sysAdmin' subsystem, ID: [sysAdmin, default]
 
@@ -135,10 +117,13 @@ Removing dev_postgres_1           ... done
 Removing dev_activemq_1           ... done
 ~~~
 
-If you have not removed the containers, it is possible to restart the tomcat instance with
-a `mvn install` (no `clean`), but this may result in failures if there are incompatibilities
-between the code, database and content in `dev/dev-acs-amps-overlay/target/dev-instance/runtime/alf_data`.
+If you have not removed the containers, it is possible to restart the tomcat instance with a `mvn install` (no `clean`), but this may result in failures if there are incompatibilities between the code, database and content in `dev/dev-acs-amps-overlay/target/dev-instance/runtime/alf_data`.
+
 Any changes made to alfresco-global properties or log4j will not be picked up, unless you
-directly edit `dev/dev-acs-amps-overlay/target/dev-instance/tomcat/shared/classes/alfresco/extension/custom-log4j2.properties`
-and `dev/dev-acs-amps-overlay/target/dev-instance/tomcat/shared/classes/alfresco-global.properties`, but they will be thrown away
-on the next `mvn clean`.
+directly edit `dev/dev-acs-amps-overlay/target/dev-instance/tomcat/shared/classes/alfresco/extension/custom-log4j2.properties` and `dev/dev-acs-amps-overlay/target/dev-instance/tomcat/shared/classes/alfresco-global.properties`, but they will be thrown away on the next `mvn clean`.
+
+## Helpful links
+
+- [alfresco-community-repo](https://github.com/Alfresco/alfresco-community-repo)
+- [alfresco-community-share](https://github.com/Alfresco/alfresco-community-share)
+- [acs-community-packaging](https://github.com/Alfresco/acs-community-packaging)


### PR DESCRIPTION
Changed:
- "entS" -> "comS" (entS does not exist),
- Improved visibility of important text in `xyz` apostrophes by bolding,
- Reedited paragrahs about building projects to make it more easy to read.

Added:
- Numbering headings to make it more like step-by-step guide,
- Xml formatting,
- Helpful links point.